### PR TITLE
fix collapse button blocking youtube controls in fullscreen

### DIFF
--- a/src/games/Games.js
+++ b/src/games/Games.js
@@ -79,7 +79,7 @@ export default function Games(props) {
       <Box sx={{ display: "flex", flexDirection: isPortrait ? "column" : "row", height: "100%", width: "100%" }}>
         <Box sx={{ display: "flex", height: "100%", width: "100%", flexDirection: "column", alignItems: "flex-start", minWidth: 0, overflow: "hidden", position: "relative" }}>
           <YoutubePlayer playerRef={playerRef} part={part} games={games} setPart={setPart} setPlaying={setPlaying} delay={delay} />
-          <Box sx={{ position: "absolute", bottom: 0, left: "50%", width: "100%" }}>
+          <Box sx={{ position: "absolute", bottom: 0, left: "50%" }}>
             <Tooltip title={showMenu ? "Collapse" : "Expand"}>
               <ExpandMore expand={showMenu} onClick={handleExpandClick} aria-expanded={showMenu} aria-label="show menu">
                 <ExpandMoreIcon />

--- a/src/vods/CustomVod.js
+++ b/src/vods/CustomVod.js
@@ -83,7 +83,7 @@ export default function Vod(props) {
       <Box sx={{ display: "flex", flexDirection: isPortrait ? "column" : "row", height: "100%", width: "100%" }}>
         <Box sx={{ display: "flex", height: "100%", width: "100%", flexDirection: "column", alignItems: "flex-start", minWidth: 0, overflow: "hidden", position: "relative" }}>
           <CustomPlayer playerRef={playerRef} setCurrentTime={setCurrentTime} setPlaying={setPlaying} delay={delay} setDelay={setDelay} type={type} vod={vod} timestamp={timestamp} />
-          <Box sx={{ position: "absolute", bottom: 0, left: "50%", width: "100%" }}>
+          <Box sx={{ position: "absolute", bottom: 0, left: "50%" }}>
             <Tooltip title={showMenu ? "Collapse" : "Expand"}>
               <ExpandMore expand={showMenu} onClick={handleExpandClick} aria-expanded={showMenu} aria-label="show menu">
                 <ExpandMoreIcon />

--- a/src/vods/YoutubeVod.js
+++ b/src/vods/YoutubeVod.js
@@ -132,7 +132,7 @@ export default function Vod(props) {
       <Box sx={{ display: "flex", flexDirection: isPortrait ? "column" : "row", height: "100%", width: "100%" }}>
         <Box sx={{ display: "flex", height: "100%", width: "100%", flexDirection: "column", alignItems: "flex-start", minWidth: 0, overflow: "hidden", position: "relative" }}>
           <YoutubePlayer playerRef={playerRef} part={part} youtube={youtube} setCurrentTime={setCurrentTime} setPart={setPart} setPlaying={setPlaying} delay={delay} />
-          <Box sx={{ position: "absolute", bottom: 0, left: "50%", width: "100%" }}>
+          <Box sx={{ position: "absolute", bottom: 0, left: "50%" }}>
             <Tooltip title={showMenu ? "Collapse" : "Expand"}>
               <ExpandMore expand={showMenu} onClick={handleExpandClick} aria-expanded={showMenu} aria-label="show menu">
                 <ExpandMoreIcon />


### PR DESCRIPTION
The collapsible section button occupies the right section blocking youtube controls when the video is fullscreen and the section is collapsed. I tested it without the width and it works fine. Also love the new game filter ❤️ 
![image](https://github.com/TimIsOverpowered/MOONMOON-Frontend/assets/40790985/8de91283-0e83-4320-acbe-3ef1797f9b20)
